### PR TITLE
windows resizable_file truncation support

### DIFF
--- a/include/decodeless/detail/mappedfile_linux.hpp
+++ b/include/decodeless/detail/mappedfile_linux.hpp
@@ -6,6 +6,7 @@
 #include <errno.h>
 #include <exception>
 #include <fcntl.h>
+#include <limits>
 #include <string.h>
 #include <string>
 #include <sys/mman.h>
@@ -159,9 +160,10 @@ private:
         }
     }
 
-    size_t       m_size;
-    address_type m_address;
-    bool         m_fixed;
+    // default initialization "should" never happen
+    size_t       m_size = std::numeric_limits<size_t>::max();
+    address_type m_address = nullptr;
+    bool         m_fixed = false;
 };
 
 using MemoryMapRO = detail::MemoryMap<PROT_READ>;

--- a/test/src/mappedfile.cpp
+++ b/test/src/mappedfile.cpp
@@ -391,6 +391,19 @@ TEST_F(MappedFileFixture, ResizeFileExtended) {
     EXPECT_FALSE(fs::exists(tmpFile2));
 }
 
+TEST_F(MappedFileFixture, ResizableFileSize) {
+    size_t lastSize = fs::file_size(m_tmpFile);
+    size_t sizes[] = {0, 1, 2, 4000, 4095, 4096, 4097, 10000, 0, 4097, 4096, 4095, 42};
+    for (size_t size : sizes) {
+        resizable_file file(m_tmpFile, 10000);
+        EXPECT_EQ(file.size(), lastSize);
+        file.resize(size);
+        EXPECT_EQ(file.size(), size);
+        lastSize = size;
+    }
+    EXPECT_EQ(fs::file_size(m_tmpFile), lastSize);
+}
+
 TEST_F(MappedFileFixture, Readme) {
     fs::path       tmpFile2 = fs::path{testing::TempDir()} / "test2.dat";
     {


### PR DESCRIPTION
Truncates the file at object destruction

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced file resizing functionality in the `ResizableFileSize` test case, allowing users to test resizing operations on files.

- **Bug Fixes**
  - Improved memory mapping and file truncation handling in Windows to ensure better resource management and file size accuracy.

- **Tests**
  - Added a new test case `ResizableFileSize` to validate file resizing functionality.
  - Updated the `Readme` test case to include new file path assignments for better coverage.

- **Documentation**
  - Added comments to clarify file truncation handling and memory-mapped file operations in the Windows implementation.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->