### PR TITLE
linux optimization: frtuncate() while mapped

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,9 @@ target_link_libraries(myproject PRIVATE decodeless::mappedfile)
 - Windows implementation uses unofficial section API for `NtExtendSection` from
   `wdm.h`/`ntdll.dll`/"WDK". Please leave a comment if you know of an
   alternative. It works well, but technically could change at any time.
+- Linux `resizable_file` maps more than the file size and truncates without
+  remapping. Simple and very fast, although not explicitly supported in the man
+  pages. Tests indicate the right thing still happens.
 
 ## Contributing
 


### PR DESCRIPTION
The main point of this change is to avoid msync() when resizing the
file. It turns out remapping is not even needed.

Disclaimer:

> If the size of the mapped file changes after the call to mmap() as a
> result of some other operation on the mapped file, the effect of
> references to portions of the mapped region that correspond to added
> or removed portions of the file is unspecified.

On linux this is a SIGBUS, but by contract of the API the user shouldn't
be writing past the resized area anyway.

An alternative could be to reserve with anonymous+private and mmap()
just the grown region like ResizableMappedMemory. However, mmap is quite
slow, even incrementally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability and consistency of file resizing and memory mapping operations on Linux.
* **Tests**
  * Simplified and reorganized test cases for mapped files, reducing fixture usage.
  * Added new tests for memory mapping edge cases and resizable file behavior, including tests for empty and cleared files.
  * Added Linux-specific tests for page residency after truncation and decommit operations.
* **Documentation**
  * Updated README with details on Linux implementation of resizable files using memory mapping and file truncation without remapping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->