### PR TITLE
Fix compilation on Linux, macOS and Windows.

### DIFF
--- a/include/decodeless/detail/mappedfile_linux.hpp
+++ b/include/decodeless/detail/mappedfile_linux.hpp
@@ -9,6 +9,7 @@
 #include <limits>
 #include <string.h>
 #include <string>
+#include <optional>
 #include <sys/mman.h>
 #include <sys/stat.h>
 #include <sys/types.h>


### PR DESCRIPTION
To fix the macOS build, I had to get rid of the use of some special options for memory mapping. `FIXED_NO_REPLACE` got replaced by `FIXED` (as only this variant is available on macOS). The fact that you don't get the guarantee from the kernel that you won't replace any mapped pages, is accounted for by the fact that the memory is pre-reserved. 
