### PR TITLE
commit only delta pages when resizing mapped memory on windows

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -9,8 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # Cannot use ubuntu-latest with clang due to github bug: https://github.com/actions/runner-images/discussions/9446
-        os: [ubuntu-20.04, ubuntu-latest, windows-latest]
+        os: [ubuntu-latest, windows-latest]
         build_type: [Debug, Release]
         c_compiler: [gcc, clang, cl]
         include:
@@ -20,7 +19,7 @@ jobs:
           - os: ubuntu-latest
             c_compiler: gcc
             cpp_compiler: g++
-          - os: ubuntu-20.04
+          - os: ubuntu-latest
             c_compiler: clang
             cpp_compiler: clang++
         exclude:
@@ -30,12 +29,6 @@ jobs:
             c_compiler: clang
           - os: ubuntu-latest
             c_compiler: cl
-          - os: ubuntu-latest
-            c_compiler: clang
-          - os: ubuntu-20.04
-            c_compiler: cl
-          - os: ubuntu-20.04
-            c_compiler: gcc
 
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Streamlined GitHub Actions workflow by removing testing on `ubuntu-20.04` and consistently using `ubuntu-latest` for Linux builds, simplifying the configuration.
  - Improved memory management logic for Windows by enforcing page alignment and optimizing how memory regions are committed or decommitted during resizing operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->