### PR TITLE
add .sync() to flush writes to disk

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2024 Pyarelal Knowles, MIT License
+# Copyright (c) 2024-2025 Pyarelal Knowles, MIT License
 
 cmake_minimum_required(VERSION 3.20)
 

--- a/README.md
+++ b/README.md
@@ -1,13 +1,14 @@
 # decodeless_mappedfile
 
-[`decodeless`](https://github.com/decodeless) (previously no-decode) is a
-collection of utility libraries for conveniently reading and writing files via
-memory mapping. Components can be used individually or combined.
+[`decodeless`](https://github.com/decodeless) is a collection of utility
+libraries for conveniently reading and writing files via memory mapping.
+Components can be used individually or combined.
 
-`decodeless_mappedfile` is a small cross platform file mapping abstraction that
-supports reserving virtual address space and growing a file mapping into it for
-an exciting new way to write binary files. Also includes convenient read-only
-and writable file mapping objects.
+`decodeless_mappedfile` is a small cross platform file mapping abstraction. It
+provides simple objects to read and write to existing files. However, the more
+interesting feature is a resizable mapped file. It works by reserving some
+virtual address space and growing a file mapping into it for a really convenient
+and fast way to write binary files.
 
 [decodeless_writer](https://github.com/decodeless/writer) conbines this and
 [decodeless_allocator](https://github.com/decodeless/allocator) to conveniently
@@ -33,16 +34,16 @@ write complex data structures directly as binary data.
 
 ## Code Example
 
-```
+```cpp
 // Memory map a read-only file
 decodeless::file mapped(filename);
 const int* numbers = reinterpret_cast<const int*>(mapped.data());
 ...
 ```
 
-```
+```cpp
 // Create a file
-size_t maxSize = 4096;
+size_t maxSize = 1 << 30;  // reserved virtual address; can be huge
 decodeless::resizable_file file(filename, maxSize);
 EXPECT_EQ(file.size(), 0);
 EXPECT_EQ(file.data(), nullptr);
@@ -56,6 +57,35 @@ numbers[9] = 9;
 file.resize(sizeof(int) * 100);
 EXPECT_EQ(numbers[9], 9);
 numbers[99] = 99;
+```
+
+## Building
+
+This is a header-only C++20 library with CMake integration. Use any of:
+
+- ```cmake
+  add_subdirectory(path/to/mappedfile)
+  ```
+
+- ```cmake
+  include(FetchContent)
+  FetchContent_Declare(
+      decodeless_mappedfile
+      GIT_REPOSITORY https://github.com/decodeless/mappedfile.git
+      GIT_TAG release_tag
+      GIT_SHALLOW TRUE
+  )
+  FetchContent_MakeAvailable(decodeless_mappedfile)
+  ```
+
+- ```cmake
+  find_package(decodeless_mappedfile REQUIRED CONFIG PATHS paths/to/search)
+  ```
+
+Then,
+
+```cmake
+target_link_libraries(myproject PRIVATE decodeless::mappedfile)
 ```
 
 ## Notes

--- a/include/decodeless/detail/mappedfile_linux.hpp
+++ b/include/decodeless/detail/mappedfile_linux.hpp
@@ -182,9 +182,9 @@ template <bool Writable>
 class MappedFile {
 public:
     using data_type = std::conditional_t<Writable, void*, const void*>;
-    MappedFile(const fs::path& path, int mapFlags = MAP_PRIVATE)
+    MappedFile(const fs::path& path)
         : m_file(path, Writable ? O_RDWR : O_RDONLY)
-        , m_mapped(nullptr, m_file.size(), mapFlags, m_file, 0) {}
+        , m_mapped(nullptr, m_file.size(), Writable ? MAP_SHARED : MAP_PRIVATE, m_file, 0) {}
 
     data_type data() const { return m_mapped.address(); }
     size_t    size() const { return m_mapped.size(); }

--- a/include/decodeless/detail/mappedfile_windows.hpp
+++ b/include/decodeless/detail/mappedfile_windows.hpp
@@ -174,8 +174,8 @@ public:
                  FILE_SHARE_READ | (Writable ? FILE_SHARE_WRITE : 0), nullptr, OPEN_EXISTING,
                  FILE_ATTRIBUTE_NORMAL, nullptr)
         , m_size(m_file.size())
-        , m_mapping(m_file, nullptr, PAGE_READONLY, m_size, nullptr)
-        , m_rawView(m_mapping, FILE_MAP_READ) {}
+        , m_mapping(m_file, nullptr, Writable ? PAGE_READWRITE : PAGE_READONLY, m_size, nullptr)
+        , m_rawView(m_mapping, FILE_MAP_READ | (Writable ? FILE_MAP_WRITE : 0)) {}
     data_type data() const { return m_rawView.address(); }
     size_t    size() const { return m_size; }
 

--- a/include/decodeless/mappedfile.hpp
+++ b/include/decodeless/mappedfile.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 Pyarelal Knowles, MIT License
+// Copyright (c) 2024-2025 Pyarelal Knowles, MIT License
 
 // Inspiration:
 // - https://nfrechette.github.io/2015/06/11/vmem_linear_allocator/
@@ -18,7 +18,9 @@
 
 namespace decodeless {
 
-// May throw std::bad_alloc or std::runtime_error (mapped_file_error or
+// These types are provided by the platform specific implementations included
+// above. Below are C++ concepts to verify a common interface. Constructors may
+// throw std::bad_alloc or std::runtime_error (mapped_file_error or
 // mapping_error)
 using file = detail::MappedFile<false>;
 using writable_file = detail::MappedFile<true>;
@@ -41,6 +43,8 @@ concept writable_mapped_file =
     std::is_constructible_v<T, fs::path> && move_only<T> && requires(T t) {
         { t.data() } -> std::same_as<void*>;
         { t.size() } -> std::same_as<size_t>;
+        { t.sync() } -> std::same_as<void>;
+        { t.sync(std::declval<size_t>(), std::declval<size_t>()) } -> std::same_as<void>;
     };
 
 template <class T>
@@ -51,9 +55,15 @@ concept resizable_mapped_memory = move_only<T> && requires(T t) {
     { t.resize(std::declval<size_t>()) } -> std::same_as<void>;
 };
 
+template <class T>
+concept resizable_mapped_file = resizable_mapped_memory<T> && requires(T t) {
+    { t.sync() } -> std::same_as<void>;
+    { t.sync(std::declval<size_t>(), std::declval<size_t>()) } -> std::same_as<void>;
+};
+
 static_assert(mapped_file<file>);
 static_assert(writable_mapped_file<writable_file>);
-static_assert(resizable_mapped_memory<resizable_file>);
+static_assert(resizable_mapped_file<resizable_file>);
 static_assert(std::is_constructible_v<resizable_file, fs::path, size_t>);
 static_assert(resizable_mapped_memory<resizable_memory>);
 static_assert(std::is_constructible_v<resizable_memory, size_t, size_t>);

--- a/test/src/mappedfile.cpp
+++ b/test/src/mappedfile.cpp
@@ -26,7 +26,21 @@ protected:
 
 TEST_F(MappedFileFixture, ReadOnly) {
     file mapped(m_tmpFile);
-    EXPECT_EQ(*reinterpret_cast<const int*>(mapped.data()), 42);
+    EXPECT_EQ(*static_cast<const int*>(mapped.data()), 42);
+}
+
+TEST_F(MappedFileFixture, Writable) {
+    {
+        writable_file mapped(m_tmpFile);
+        ASSERT_GE(mapped.size(), sizeof(int));
+        *static_cast<int*>(mapped.data()) = 123;
+    }
+    {
+        std::ifstream ifile(m_tmpFile, std::ios::binary);
+        int           contents;
+        ifile.read(reinterpret_cast<char*>(&contents), sizeof(contents));
+        EXPECT_EQ(contents, 123);
+    }
 }
 
 #ifdef _WIN32


### PR DESCRIPTION
Add writable_file::sync() and resizable_file::sync() with optional
offset and size arguments

Drive-by fix for likely outdated NtQuerySection definition

Removed unused ntifs() dll module singleton

Renamed SectionPageProtection that used to shadow a createSection()
parameter

Fix writable_file mapping permissions. Was outright missing write permissions on windows and private/non-shared
on linux.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added explicit synchronization methods for memory-mapped files, allowing users to flush changes to disk either for the entire file or for a specific range, on both Linux and Windows.
  * Introduced new C++ concepts to validate the interface of writable and resizable mapped file types.

* **Bug Fixes**
  * Improved type correctness and pointer arithmetic for better compatibility and reliability on Windows.

* **Documentation**
  * Enhanced README with clearer descriptions, updated usage examples, and detailed build instructions.

* **Tests**
  * Added tests to verify writable memory mapping and explicit synchronization of file changes.

* **Chores**
  * Updated copyright year to 2024-2025.
  * Improved code comments for clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->