### PR TITLE
MAP_SHARED even for read-only

### DIFF
--- a/include/decodeless/detail/mappedfile_linux.hpp
+++ b/include/decodeless/detail/mappedfile_linux.hpp
@@ -196,7 +196,7 @@ public:
     using data_type = std::conditional_t<Writable, void*, const void*>;
     MappedFile(const fs::path& path)
         : m_file(path, Writable ? O_RDWR : O_RDONLY)
-        , m_mapped(nullptr, m_file.size(), Writable ? MAP_SHARED : MAP_PRIVATE, m_file, 0) {}
+        , m_mapped(nullptr, m_file.size(), MAP_SHARED, m_file, 0) {}
 
     data_type data() const { return m_mapped.address(); }
     size_t    size() const { return m_mapped.size(); }


### PR DESCRIPTION
MAP_PRIVATE is backed by swap, which limits the maximum size

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated memory mapping behavior to ensure consistent file access patterns across all usage scenarios. No changes to the public API.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->